### PR TITLE
Bugfix/shape docu

### DIFF
--- a/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/datatype-reference/index.md
+++ b/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/datatype-reference/index.md
@@ -16,11 +16,13 @@ This is a list of supported data types in shapes.
 
 #### anyURI
 
+
 The ·lexical space· of anyURI is finite-length character sequences which, when the algorithm defined in Section 5.4 of [XML Linking Language] is applied to them, result in strings which are legal URIs according to [RFC 2396], as amended by [RFC 2732]. Note:  Spaces are, in principle, allowed in the ·lexical space· of anyURI, however, their use is highly discouraged (unless they are encoded by %20).
 
 IRI: `http://www.w3.org/2001/XMLSchema#anyURI`
 
 #### base64Binary
+
 
 The lexical forms of base64Binary values are limited to the 65 characters of the Base64 Alphabet defined in [RFC 2045], i.e., a-z, A-Z, 0-9, the plus sign (+), the forward slash (/) and the equal sign (=), together with the characters defined in [XML 1.0 (Second Edition)] as white space. No other characters are allowed.
 
@@ -28,11 +30,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#base64Binary`
 
 #### boolean
 
+
 An instance of a datatype that is defined as ·boolean· can have the following legal literals {true, false, 1, 0}.
 
 IRI: `http://www.w3.org/2001/XMLSchema#boolean`
 
 #### byte
+
 
 byte is ·derived· from short by setting the value of ·maxInclusive· to be 127 and ·minInclusive· to be -128. byte has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126, +100.
 
@@ -40,17 +44,20 @@ IRI: `http://www.w3.org/2001/XMLSchema#byte`
 
 #### date
 
-The lexical space of date consists of finite-length sequences of characters of the form: `'-'? yyyy '-' mm '-' dd zzzzzz?` where the date and optional timezone are represented exactly the same way as they are for dateTime. The first moment of the interval is that represented by: `'-' yyyy '-' mm '-' dd 'T00:00:00' zzzzzz?` and the least upper bound of the interval is the timeline point represented (noncanonically) by: `'-' yyyy '-' mm '-' dd 'T24:00:00' zzzzzz?`.
+
+The ·lexical space· of date consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd zzzzzz? where the date and optional timezone are represented exactly the same way as they are for dateTime. The first moment of the interval is that represented by: '-' yyyy '-' mm '-' dd 'T00:00:00' zzzzzz? and the least upper bound of the interval is the timeline point represented (noncanonically) by: '-' yyyy '-' mm '-' dd 'T24:00:00' zzzzzz?.
 
 IRI: `http://www.w3.org/2001/XMLSchema#date`
 
 #### dateTime
 
-The ·lexical space· of dateTime consists of finite-length sequences of characters of the form: `'-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)?` For example, `2002-10-10T12:00:00-05:00` (noon on 10 October 2002, Central Daylight Savings Time as well as Eastern Standard Time in the U.S.) is `2002-10-10T17:00:00Z`, five hours later than `2002-10-10T12:00:00Z`.
+
+The ·lexical space· of dateTime consists of finite-length sequences of characters of the form: '-'? yyyy '-' mm '-' dd 'T' hh ':' mm ':' ss ('.' s+)? (zzzzzz)? For example, 2002-10-10T12:00:00-05:00 (noon on 10 October 2002, Central Daylight Savings Time as well as Eastern Standard Time in the U.S.) is 2002-10-10T17:00:00Z, five hours later than 2002-10-10T12:00:00Z.
 
 IRI: `http://www.w3.org/2001/XMLSchema#dateTime`
 
 #### dateTimeStamp
+
 
 The lexical space of dateTimeStamp consists of strings which are in the ·lexical space· of dateTime and which also match the regular expression '.*(Z|(+|-)[0-9][0-9]:[0-9][0-9])'
 
@@ -58,11 +65,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#dateTimeStamp`
 
 #### decimal
 
+
 decimal has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39) separated by a period as a decimal indicator. An optional leading sign is allowed. If the sign is omitted, '+' is assumed. Leading and trailing zeroes are optional. If the fractional part is zero, the period and following zeroes can be omitted. For example: -1.23, 12678967.543233, +100000.00, 210.
 
 IRI: `http://www.w3.org/2001/XMLSchema#decimal`
 
 #### double
+
 
 double values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for double.
 
@@ -70,11 +79,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#double`
 
 #### duration
 
-The lexical representation for duration is the ISO 8601 extended format `PnYnMnDTnHnMnS`, where `nY` represents the number of years, `nM` the number of months, `nD` the number of days, `T` is the date/time separator, `nH` the number of hours, `nM` the number of minutes and `nS` the number of seconds. The number of seconds can include decimal digits to arbitrary precision.
+
+The lexical representation for duration is the [ISO 8601] extended format PnYn MnDTnH nMnS, where nY represents the number of years, nM the number of months, nD the number of days, 'T' is the date/time separator, nH the number of hours, nM the number of minutes and nS the number of seconds. The number of seconds can include decimal digits to arbitrary precision.
 
 IRI: `http://www.w3.org/2001/XMLSchema#duration`
 
 #### float
+
 
 float values have a lexical representation consisting of a mantissa followed, optionally, by the character 'E' or 'e', followed by an exponent. The exponent ·must· be an integer. The mantissa must be a decimal number. The representations for exponent and mantissa must follow the lexical rules for integer and decimal. If the 'E' or 'e' and the following exponent are omitted, an exponent value of 0 is assumed. The special values positive and negative infinity and not-a-number have lexical representations INF, -INF and NaN, respectively. Lexical representations for zero may take a positive or negative sign. For example, -1E4, 1267.43233E12, 12.78e-2, 12 , -0, 0 and INF are all legal literals for float.
 
@@ -82,29 +93,34 @@ IRI: `http://www.w3.org/2001/XMLSchema#float`
 
 #### gDay
 
-The lexical representation for gDay is the left truncated lexical representation for date: `---DD` . An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats.
+
+The lexical representation for gDay is the left truncated lexical representation for date: ---DD . An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).
 
 IRI: `http://www.w3.org/2001/XMLSchema#gDay`
 
 #### gMonth
 
-The lexical representation for gMonth is the left and right truncated lexical representation for date: `--MM`. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats.
+
+The lexical representation for gMonth is the left and right truncated lexical representation for date: --MM. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D).
 
 IRI: `http://www.w3.org/2001/XMLSchema#gMonth`
 
 #### gMonthDay
 
-The lexical representation for gMonthDay is the left truncated lexical representation for date: `--MM-DD`. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats. This datatype can be used to represent a specific day in a month. To say, for example, that my birthday occurs on the 14th of September ever year.
+
+The lexical representation for gMonthDay is the left truncated lexical representation for date: --MM-DD. An optional following time zone qualifier is allowed as for date. No preceding sign is allowed. No other formats are allowed. See also ISO 8601 Date and Time Formats (·D). This datatype can be used to represent a specific day in a month. To say, for example, that my birthday occurs on the 14th of September ever year.
 
 IRI: `http://www.w3.org/2001/XMLSchema#gMonthDay`
 
 #### gYear
 
-The lexical representation for gYear is the reduced (right truncated) lexical representation for dateTime: `CCYY`. No left truncation is allowed. An optional following time zone qualifier is allowed as for dateTime. To accommodate year values outside the range from `0001` to `9999`, additional digits can be added to the left of this representation and a preceding `-` sign is allowed. For example, to indicate 1999, one would write: `1999`. See also ISO 8601 Date and Time Formats.
+
+The lexical representation for gYear is the reduced (right truncated) lexical representation for dateTime: CCYY. No left truncation is allowed. An optional following time zone qualifier is allowed as for dateTime. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate 1999, one would write: 1999. See also ISO 8601 Date and Time Formats (·D).
 
 IRI: `http://www.w3.org/2001/XMLSchema#gYear`
 
 #### gYearMonth
+
 
 The lexical representation for gYearMonth is the reduced (right truncated) lexical representation for dateTime: CCYY-MM. No left truncation is allowed. An optional following time zone qualifier is allowed. To accommodate year values outside the range from 0001 to 9999, additional digits can be added to the left of this representation and a preceding '-' sign is allowed. For example, to indicate the month of May 1999, one would write: 1999-05. See also ISO 8601 Date and Time Formats (·D).
 
@@ -112,11 +128,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#gYearMonth`
 
 #### hexBinary
 
+
 hexBinary has a lexical representation where each binary octet is encoded as a character tuple, consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code. For example, '0FB7' is a hex encoding for the 16-bit integer 4023 (whose binary representation is 111110110111).
 
 IRI: `http://www.w3.org/2001/XMLSchema#hexBinary`
 
 #### HTML
+
 
 The datatype of RDF literals storing fragments of HTML content
 
@@ -124,17 +142,20 @@ IRI: `http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML`
 
 #### int
 
+
 int is ·derived· from long by setting the value of ·maxInclusive· to be 2147483647 and ·minInclusive· to be -2147483648. int has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 126789675, +100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#int`
 
 #### integer
 
+
 integer has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39) with an optional leading sign. If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#integer`
 
-#### Jinja Template String
+#### Jinja Template String (datatype)
+
 
 Jinja is a modern and designer-friendly templating language for Python and other languages.
 
@@ -142,11 +163,13 @@ IRI: `https://vocab.eccenca.com/shui/jinja`
 
 #### langString
 
+
 The datatype of language-tagged string values
 
 IRI: `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`
 
 #### language
+
 
 language represents natural language identifiers as defined by by [RFC 3066] . The ·value space· of language is the set of all strings that are valid language identifiers as defined [RFC 3066] . The ·lexical space· of language is the set of all strings that conform to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* . The ·base type· of language is token.
 
@@ -154,11 +177,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#language`
 
 #### long
 
+
 long is ·derived· from integer by setting the value of ·maxInclusive· to be 9223372036854775807 and ·minInclusive· to be -9223372036854775808. long has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678967543233, +100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#long`
 
 #### Markdown
+
 
 In addition to rdf:HTML, this is the datatype of RDF literals storing fragments of markdown content. eccenca Corporate Memory user interfaces support the rendering of all basic Markdown syntax features as well as the extensions for tables, code blocks, strikethrough, task lists and footnotes.
 
@@ -166,11 +191,13 @@ IRI: `http://ns.ontowiki.net/SysOnt/Markdown`
 
 #### Name
 
+
 Name represents XML Names. The ·value space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·lexical space· of Name is the set of all strings which ·match· the Name production of [XML 1.0 (Second Edition)]. The ·base type· of Name is token.
 
 IRI: `http://www.w3.org/2001/XMLSchema#Name`
 
 #### NCName
+
 
 NCName represents XML 'non-colonized' Names. The ·value space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·lexical space· of NCName is the set of all strings which ·match· the NCName production of [Namespaces in XML]. The ·base type· of NCName is Name.
 
@@ -178,11 +205,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#NCName`
 
 #### negativeInteger
 
+
 negativeInteger has a lexical representation consisting of a negative sign ('-') followed by a finite-length sequence of decimal digits (#x30-#x39). For example: -1, -12678967543233, -100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#negativeInteger`
 
 #### NMTOKEN
+
 
 NMTOKEN represents the NMTOKEN attribute type from [XML 1.0 (Second Edition)]. The ·value space· of NMTOKEN is the set of tokens that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·lexical space· of NMTOKEN is the set of strings that ·match· the Nmtoken production in [XML 1.0 (Second Edition)]. The ·base type· of NMTOKEN is token.
 
@@ -190,11 +219,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#NMTOKEN`
 
 #### nonNegativeInteger
 
+
 nonNegativeInteger has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, the positive sign ('+') is assumed. If the sign is present, it must be '+' except for lexical forms denoting zero, which may be preceded by a positive ('+') or a negative ('-') sign. For example: 1, 0, 12678967543233, +100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#nonNegativeInteger`
 
 #### nonPositiveInteger
+
 
 nonPositiveInteger has a lexical representation consisting of an optional preceding sign followed by a finite-length sequence of decimal digits (#x30-#x39). The sign may be '+' or may be omitted only for lexical forms denoting zero, in all other lexical forms, the negative sign ('-') must be present. For example: -1, 0, -12678967543233, -100000.
 
@@ -202,11 +233,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#nonPositiveInteger`
 
 #### normalizedString
 
+
 normalizedString represents white space normalized strings. The ·value space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·lexical space· of normalizedString is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters. The ·base type· of normalizedString is string.
 
 IRI: `http://www.w3.org/2001/XMLSchema#normalizedString`
 
 #### PlainLiteral
+
 
 The class of plain (i.e. untyped) literal values, as used in RIF and OWL 2
 
@@ -214,11 +247,13 @@ IRI: `http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral`
 
 #### positiveInteger
 
+
 positiveInteger has a lexical representation consisting of an optional positive sign ('+') followed by a finite-length sequence of decimal digits (#x30-#x39). For example: 1, 12678967543233, +100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#positiveInteger`
 
 #### short
+
 
 short is ·derived· from int by setting the value of ·maxInclusive· to be 32767 and ·minInclusive· to be -32768. short has a lexical representation consisting of an optional sign followed by a finite-length sequence of decimal digits (#x30-#x39). If the sign is omitted, '+' is assumed. For example: -1, 0, 12678, +10000.
 
@@ -226,11 +261,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#short`
 
 #### sparqlOperation
 
+
 sparql operation datatype (query or update)
 
 IRI: `https://vocab.eccenca.com/shui/sparqlOperation`
 
 #### sparqlQuery
+
 
 SPARQL 1.1 Query
 
@@ -238,11 +275,13 @@ IRI: `https://vocab.eccenca.com/shui/sparqlQuery`
 
 #### sparqlUpdate
 
+
 SPARQL 1.1 Update
 
 IRI: `https://vocab.eccenca.com/shui/sparqlUpdate`
 
 #### string
+
 
 The string datatype represents character strings in XML. The ·value space· of string is the set of finite-length sequences of characters (as defined in [XML 1.0 (Second Edition)]) that ·match· the Char production from [XML 1.0 (Second Edition)]. A character is an atomic unit of communication, it is not further specified except to note that every character has a corresponding Universal Character Set code point, which is an integer.
 
@@ -250,11 +289,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#string`
 
 #### time
 
-The lexical representation for time is the left truncated lexical representation for dateTime: `hh:mm:ss.sss` with optional following time zone indicator. For example, to indicate 1:20 pm for Eastern Standard Time which is 5 hours behind Coordinated Universal Time (UTC), one would write: `13:20:00-05:00`. See also ISO 8601 Date and Time Formats.
+
+The lexical representation for time is the left truncated lexical representation for dateTime: hh:mm:ss.sss with optional following time zone indicator. For example, to indicate 1:20 pm for Eastern Standard Time which is 5 hours behind Coordinated Universal Time (UTC), one would write: 13:20:00-05:00. See also ISO 8601 Date and Time Formats (·D).
 
 IRI: `http://www.w3.org/2001/XMLSchema#time`
 
 #### token
+
 
 token represents tokenized strings. The ·value space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·lexical space· of token is the set of strings that do not contain the carriage return (#xD), line feed (#xA) nor tab (#x9) characters, that have no leading or trailing spaces (#x20) and that have no internal sequences of two or more spaces. The ·base type· of token is normalizedString.
 
@@ -262,11 +303,13 @@ IRI: `http://www.w3.org/2001/XMLSchema#token`
 
 #### unsignedByte
 
+
 unsignedByte is ·derived· from unsignedShort by setting the value of ·maxInclusive· to be 255. unsignedByte has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 126, 100.
 
 IRI: `http://www.w3.org/2001/XMLSchema#unsignedByte`
 
 #### unsignedInt
+
 
 unsignedInt is ·derived· from unsignedLong by setting the value of ·maxInclusive· to be 4294967295. unsignedInt has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 1267896754, 100000.
 
@@ -274,17 +317,20 @@ IRI: `http://www.w3.org/2001/XMLSchema#unsignedInt`
 
 #### unsignedLong
 
+
 unsignedLong is ·derived· from nonNegativeInteger by setting the value of ·maxInclusive· to be 18446744073709551615. unsignedLong has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678967543233, 100000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#unsignedLong`
 
 #### unsignedShort
 
+
 unsignedShort is ·derived· from unsignedInt by setting the value of ·maxInclusive· to be 65535. unsignedShort has a lexical representation consisting of a finite-length sequence of decimal digits (#x30-#x39). For example: 0, 12678, 10000.
 
 IRI: `http://www.w3.org/2001/XMLSchema#unsignedShort`
 
 #### XMLLiteral
+
 
 The datatype of XML literal values.
 

--- a/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/node-shapes/index.md
+++ b/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/node-shapes/index.md
@@ -22,6 +22,7 @@ This page lists all supported properties to describe node shapes.
 
 ### Name
 
+
 The name of the node is presented to the user only when he needs to distinguish between different shapes for the same resource.
 
 Used Path: `shacl:name`
@@ -29,19 +30,30 @@ Used Path: `shacl:name`
 
 ### Description
 
+
 The node description should provide context information for the user when creating a new resource based on this node.
 
 Used Path: `rdfs:comment`
 
 
+### Tab Name (deprecated)
+
+
+Name of the tab (deprecated, only interpreted until 20.06)
+
+Used Path: `shui:tabName`
+
+
 ### Navigation list query
 
-This property links the node shape to a SPARQL 1.1 Query in order to provide a sophisticated user navigation list query e.g. to add specific additional columns. The query should use  as a placeholder for the FROM section. Additionally,  can be used to access the graph in the FROM section.
+
+This property links the node shape to a SPARQL 1.1 Query in order to provide a sophisticated user navigation list query e.g. to add specific additional columns. The query should use {{FROM}} as a placeholder for the FROM section. Additionally, {{GRAPH}} can be used to access the graph in the FROM section.
 
 Used Path: `shui:navigationListQuery`
 
 
 ### Depiction Image
+
 
 This property links a node shape to an image in order to use this image when showing resources based on this node shape somewhere.
 
@@ -54,12 +66,14 @@ Used Path: `http://xmlns.com/foaf/0.1/depiction`
 
 ### Property Shapes
 
+
 The used property shapes on this node. Please note that this is NOT a link to a datatype or object property but to a SHACL property shape.
 
 Used Path: `shacl:property`
 
 
 ### Target class
+
 
 Class this NodeShape applies to. This is a direct link to a class resource from a vocabulary.
 
@@ -72,6 +86,7 @@ Used Path: `shacl:targetClass`
 
 ### URI template
 
+
 A compact sequence of characters for describing a range of URIs through variable expansion.
 
 Used Path: `shui:uriTemplate`
@@ -80,17 +95,21 @@ Used Path: `shui:uriTemplate`
 ### On update update
 
 
+
 A query which is executed when this nodeshape is submitted.
 The query should be saved in the same graph as the shape (or imported).
+
 The query can use these placeholders:
- - the resource currently shown with the node shape of this property shape,
- - the currently used graph. 
+
+- `{{shuiResource}}` - the resource currently shown with the node shape of this property shape,
+- `{{shuiGraph}}` - the currently used graph. 
 
 
 Used Path: `shui:onUpdateUpdate`
 
 
 ### Target Graph Template
+
 
 Graph templates can be used to enforce writing statement in specific graphs rather than into the selected graph. Graph templates can be added to node and property shapes. A template on a property shape is used only for overwriting a template on a node shape (without a node shape graph template, they do not have an effect).
 
@@ -103,12 +122,14 @@ Used Path: `shui:targetGraphTemplate`
 
 ### Enable
 
+
 A value of true enables visualisation and management capabilities of statement annotations (reification) for all statements which are shown via this shape.
 
 Used Path: `shui:enableStatementLevelMetadata`
 
 
 ### Provide as Shape
+
 
 A value of true enables this node shape to be applied as statement annotation (reification).
 

--- a/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/property-shapes/index.md
+++ b/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/property-shapes/index.md
@@ -48,11 +48,12 @@ Used Path: `shacl:description`
 
 Use this property to provide a tabular read-only report of a custom SPARQL query at the place where this property shape is used in the user interface.
 
-The following placeholder can be used in the query text of the sparql query:
+The following placeholder can be used in the query text of the SPARQL query:
 
 - `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
 - `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
 - `{{shuiGraph}}` - the currently used graph.
+
 
 Used Path: `shui:valueQuery`
 
@@ -166,7 +167,7 @@ Used Path: `shacl:datatype`
 ### Use textarea
 
 
-Default is false. A value of true enables multiline editing capabilities for Literals via a textarea widget.
+Default is false. A value of true enables multiline editing capabilities for Literals via a `textarea` widget.
 
 Used Path: `shui:textarea`
 
@@ -190,7 +191,7 @@ Used Path: `shacl:flags`
 ### Languages allowed
 
 
-This limits the given Literals to a list of languages. This property works only in combination with the datatype rdf:langString. Note that the expression for this property only allows for '2 Char ISO-639-1-Codes' only (no sub-tags).
+This limits the given Literals to a list of languages. This property works only in combination with the datatype `rdf:langString`. Note that the expression for this property only allows for '2 Char ISO-639-1-Codes' only (no sub-tags).
 
 Used Path: `shui:languageIn`
 
@@ -274,7 +275,7 @@ Used Path: `shui:ignoreOnCopy`
 
 This query is executed when a property value is added or changed.
 
-The following placeholder can be used in the query text of the sparql query:
+The following placeholder can be used in the query text of the SPARQL query:
 
 - `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
 - `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
@@ -289,7 +290,7 @@ Used Path: `shui:onInsertUpdate`
 
 This query is executed when a value is changed or removed.
 
-The following placeholder can be used in the query text of the sparql query:
+The following placeholder can be used in the query text of the SPARQL query:
 
 - `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
 - `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;

--- a/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/property-shapes/index.md
+++ b/docs/explore-and-author/graph-exploration/building-a-customized-user-interface/property-shapes/index.md
@@ -12,76 +12,97 @@ They are used to specify constraints and UI options that need to be met in the 
 
 The following Property Shape properties are supported:
 
+
 ## Naming and Presentation
 
 !!! info
 
     In this group, presentation and naming properties are collected. Most of the properties are straight forward to use, other properties provide more complex features, such as table reports.
 
+### Provide Workflow Trigger
+
+
+Integrates a workflow trigger button in order to execute workflows from or with this resource.
+
+Used Path: `shui:provideWorkflowTrigger`
+
+
 ### Name
+
 
 This name will be shown to the user.
 
 Used Path: `shacl:name`
 
+
 ### Description
+
 
 This text will be shown to the user in a tooltip. You can use new and blank lines for basic text structuring.
 
 Used Path: `shacl:description`
 
+
 ### Query: Table Report
 
-Use this property to provide a tabular read-only report of a custom SPARQL query at the place where this property shape is used in the user interface.
-The following placeholder can be used in the query text of the SPARQL query:
 
--   refers to the main resource rendered in the starte node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
--   refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
--   the currently used graph.
+Use this property to provide a tabular read-only report of a custom SPARQL query at the place where this property shape is used in the user interface.
+
+The following placeholder can be used in the query text of the sparql query:
+
+- `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
+- `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
+- `{{shuiGraph}}` - the currently used graph.
 
 Used Path: `shui:valueQuery`
 
+
 ### Query: Table Report (hide header)
+
 
 If set to true, the report table will be rendered without header (in case you expect only a single value).
 
 Used Path: `shui:valueQueryHideHeader`
 
+
 ### Query: Table Report (hide footer)
+
 
 If set to true, the report table will be rendered without footer (in case you expect only a single value or row).
 
 Used Path: `shui:valueQueryHideFooter`
 
+
 ### Order
+
 
 Specifies the order of the property in the UI. Ordering is separate for each group.
 
 Used Path: `shacl:order`
 
+
 ### Group
+
 
 Group to which the property belongs to.
 
 Used Path: `shacl:group`
 
+
 ### Show always
+
 
 Default is false. A value of true let optional properties (min count = 0) show up by default.
 
 Used Path: `shui:showAlways`
 
+
 ### Read only
+
 
 Default is false. A value of true means the properties are not editable by the user. Useful for displaying system properties.
 
 Used Path: `shui:readOnly`
-
-### Provide Workflow Trigger
-
-Integrates a workflow trigger button in order to execute workflows from or with this resource.
-
-Used Path: `shui:provideWorkflowTrigger`
 
 ## Vocabulary
 
@@ -91,29 +112,38 @@ Used Path: `shui:provideWorkflowTrigger`
 
 ### Property of
 
+
 The node shape this property shape belongs to.
 
 Used Path: `shacl:property`
 
+
 ### Path
+
 
 The datatype or object property used in this shape.
 
 Used Path: `shacl:path`
 
+
 ### Node kind
+
 
 Type of the node.
 
 Used Path: `shacl:nodeKind`
 
+
 ### Min count
+
 
 Min cardinality, 0 will show this property under optionals unless 'Show always = true'
 
 Used Path: `shacl:minCount`
 
+
 ### Max count
+
 
 Max cardinality
 
@@ -127,35 +157,46 @@ Used Path: `shacl:maxCount`
 
 ### Datatype
 
+
 The datatype of the property.
 
 Used Path: `shacl:datatype`
 
+
 ### Use textarea
 
-Default is false. A value of true enables multiline editing capabilities for Literals via a `textarea` widget.
+
+Default is false. A value of true enables multiline editing capabilities for Literals via a textarea widget.
 
 Used Path: `shui:textarea`
 
+
 ### Regex Pattern
+
 
 A XPath regular expression (Perl like) that all literal strings need to match.
 
 Used Path: `shacl:pattern`
 
+
 ### Regex Flags
+
 
 An optional string of flags for the regular expression pattern (e.g. 'i' for case-insensitive mode)
 
 Used Path: `shacl:flags`
 
+
 ### Languages allowed
 
-This limits the given Literals to a list of languages. This property works only in combination with the datatype `rdf:langString`. Note that the expression for this property only allows for '2 Char ISO-639-1-Codes' only (no sub-tags).
+
+This limits the given Literals to a list of languages. This property works only in combination with the datatype rdf:langString. Note that the expression for this property only allows for '2 Char ISO-639-1-Codes' only (no sub-tags).
 
 Used Path: `shui:languageIn`
 
+
 ### Languages Unique
+
 
 Default is false. A value of true enforces that no pair of Literals may use the same language tag.
 
@@ -169,29 +210,38 @@ Used Path: `shacl:uniqueLang`
 
 ### Class
 
+
 Class of the connected IRI if nodeKind == sh:IRI.
 
 Used Path: `shacl:class`
 
+
 ### Query: Selectable Resources
+
 
 This query allows for listing selectable resources in the dropdown list for this property shape.
 
 Used Path: `shui:uiQuery`
 
+
 ### Inverse Path
+
 
 Default is false. A value of true inverts the expected / created direction of a relation.
 
 Used Path: `shui:inversePath`
 
+
 ### Deny new resources
+
 
 A value of true disables the option to create new resources.
 
 Used Path: `shui:denyNewResources`
 
+
 ### Node shape
+
 
 The shape of the linked resource.
 
@@ -205,41 +255,52 @@ Used Path: `shacl:node`
 
 ### URI template
 
+
 A compact sequence of characters for describing a range of URIs through variable expansion.
 
 Used Path: `shui:uriTemplate`
 
+
 ### Ignore on copy
+
 
 Disables reusing the value(s) when creating a copy of the resource.
 
 Used Path: `shui:ignoreOnCopy`
 
+
 ### Query: On insert update
+
 
 This query is executed when a property value is added or changed.
 
-The following placeholder can be used in the query text of the SPARQL query:
+The following placeholder can be used in the query text of the sparql query:
 
--   refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
--   refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
--   the currently used graph.
+- `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
+- `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
+- `{{shuiGraph}}` - the currently used graph.
+    
 
 Used Path: `shui:onInsertUpdate`
 
+
 ### Query: On delete update
+
 
 This query is executed when a value is changed or removed.
 
-The following placeholder can be used in the query text of the SPARQL query:
+The following placeholder can be used in the query text of the sparql query:
 
--   refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
--   refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
--   the currently used graph.
+- `{{shuiMainResource}}` - refers to the main resource rendered in the start node shape of the currently displayed node shape tree (only relevant in case of sub-shape usage) ;
+- `{{shuiResource}}` - refers to the resource which is rendered in the node shape where this property shape is used (maybe a sub-shape) ;
+- `{{shuiGraph}}` - the currently used graph.
+    
 
 Used Path: `shui:onDeleteUpdate`
 
+
 ### Target Graph Template
+
 
 Graph templates can be used to enforce writing statement in specific graphs rather than into the selected graph. Graph templates can be added to node and property shapes. A template on a property shape is used only for overwriting a template on a node shape (without a node shape graph template, they do not have an effect).
 
@@ -253,11 +314,14 @@ Used Path: `shui:targetGraphTemplate`
 
 ### Enable
 
-A value of true enables visualization and management capabilities of statement annotations (reification) for all statements which are shown via this shape.
+
+A value of true enables visualisation and management capabilities of statement annotations (reification) for all statements which are shown via this shape.
 
 Used Path: `shui:enableStatementLevelMetadata`
 
+
 ### Provided Shapes
+
 
 Instead of providing all possible statement annotation node shapes for the creation of new statement annotations, this property will limit the list to the selected shapes only.
 

--- a/tools/update-shape-reference/shapedocu.ttl
+++ b/tools/update-shape-reference/shapedocu.ttl
@@ -69,7 +69,11 @@ ORDER BY ASC(?groupOrder) ASC(?propertyOrder)
 
 ### {{ result.property }}
 
-{{ result.description }}
+{#
+# wrapping {{placeholder}} in `raw` environment in order to have it in the output
+# https://stackoverflow.com/questions/55463849/how-can-i-escape-double-curly-braces-in-jinja2
+#}
+{{ result.description | replace('{{', '{% raw %}{{') | replace('}}', '}}{% endraw %}') }}
 
 Used Path: `{{ result.path }}`
 {% endfor %}"""^^shui:jinja ;
@@ -135,7 +139,11 @@ ORDER BY ASC(?groupOrder) ASC(?propertyOrder)
 
 ### {{ result.property }}
 
-{{ result.description }}
+{#
+# wrapping {{placeholder}} in `raw` environment in order to have it in the output
+# https://stackoverflow.com/questions/55463849/how-can-i-escape-double-curly-braces-in-jinja2
+#}
+{{ result.description | replace('{{', '{% raw %}{{') | replace('}}', '}}{% endraw %}') }}
 
 Used Path: `{{ result.path }}`
 {% endfor %}"""^^shui:jinja ;
@@ -179,7 +187,11 @@ ORDER BY ASC(LCASE(?label))"""^^shui:sparqlQuery ;
     rdfs:label "Datatype Documentation Template" ;
     shui:selectResultTemplateBody """{% for result in results %}#### {{ result.label }}
 
-{{ result.description }}
+{#
+# wrapping {{placeholder}} in `raw` environment in order to have it in the output
+# https://stackoverflow.com/questions/55463849/how-can-i-escape-double-curly-braces-in-jinja2
+#}
+{{ result.description | replace('{{', '{% raw %}{{') | replace('}}', '}}{% endraw %}') }}
 
 IRI: `{{ result.iri }}`
 


### PR DESCRIPTION
regenerate shape docu.
related to / depends on https://gitlab.eccenca.com/elds/backend/-/merge_requests/605

WIP ... need to understand why many in-line code markup in `datatype-reference/index.md` was removed ... I assume just not having the proper/latest sources for this.