### PR TITLE
Add Related Plugins section to plugin reference pages

### DIFF
--- a/tools/templates/plugin.md
+++ b/tools/templates/plugin.md
@@ -25,3 +25,12 @@ tags: {% for tag in plugin.tags %}
 ## Advanced Parameter
 
 {{parameters_advanced if plugin.properties_advanced else "`None`"}}
+
+{%- if plugin.relatedPlugins %}
+
+## Related Plugins
+
+{% for ref in plugin.relatedPlugins -%}
+- **{{ ref.id }}**{% if ref.description %} — {{ ref.description }}{% endif %}
+{% endfor %}
+{%- endif %}

--- a/tools/update_di_reference.py
+++ b/tools/update_di_reference.py
@@ -27,6 +27,13 @@ jinja_environment = Environment(
 def stripped_single_line(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
 
+class PluginReference(BaseModel):
+    """Reference to a related plugin."""
+
+    id: str
+    description: str | None = None
+
+
 class ActionDescription(BaseModel):
     """Action description"""
 
@@ -82,6 +89,7 @@ class PluginDescription(BaseModel):
     is_deprecated: bool | None = None
     tags: list[str] = Field(default_factory=list)
     pluginType: str | None = None
+    relatedPlugins: list[PluginReference] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def move_advanced_properties(self) -> Self:
@@ -173,8 +181,8 @@ def create_plugin_markdown(plugin: PluginDescription, plugin_type: str, base_dir
 
     content = plugin_template.render(
         plugin=plugin,
-        parameters=parameter_content,
-        parameters_advanced=parameter_advanced_content,
+        parameters=parameter_content.rstrip("\n"),
+        parameters_advanced=parameter_advanced_content.rstrip("\n"),
     )
 
     # create the file (incl. directory)


### PR DESCRIPTION
# Related Plugins section in plugin reference pages

Adds a `PluginReference` Pydantic model and a `relatedPlugins` field to `PluginDescription` in `update_di_reference.py`, so the field is deserialized from the DI API response. Updates `plugin.md` to render a "Related Plugins" section at the bottom of each plugin page when the list is non-empty, showing the plugin ID and an optional description of the relationship.

Part of CMEM-7549.

---

Depends on https://github.com/eccenca/cmem-plugin-base/pull/40 and https://gitlab.eccenca.com/elds/data-integration/-/merge_requests/1495

